### PR TITLE
Updating expo-linear-gradient to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "typescript": "^3.6.4"
   },
   "dependencies": {
-    "expo-linear-gradient": "^7.0.1",
+    "expo-linear-gradient": "^8.0.0",
     "lodash": "^4.17.14"
   }
 }


### PR DESCRIPTION
Updating expo-linear-gradient to latest version corresponding to expo SDK 36.