### PR TITLE
Change type of containerStyle prop to StyleProp<ViewStyle>

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -1,4 +1,4 @@
-import { Easing, EasingFunction, ViewStyle } from 'react-native';
+import { Easing, EasingFunction, StyleProp, ViewStyle } from 'react-native';
 
 type animationType = 'none' | 'shiver' | 'pulse';
 type animationDirection =
@@ -17,7 +17,7 @@ export interface ISkeletonContentProps {
   isLoading: boolean;
   layout?: CustomViewStyle[];
   duration?: number;
-  containerStyle?: ViewStyle;
+  containerStyle?: StyleProp<ViewStyle>;
   animationType?: 'none' | 'shiver' | 'pulse';
   animationDirection?:
     | 'horizontalLeft'


### PR DESCRIPTION
This allows using an array of styles as well!

For example:
```tsx
<SkeletonContent
    containerStyle={[styles.container, styles.someOtherStyles]}
    ...
```
This is the correct type since that's what `View` accepts as the `style` prop. So passing an array was working anyway although Typescript was complaining.