### PR TITLE
Restart animation on component update

### DIFF
--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -122,6 +122,12 @@ export default class SkeletonContent extends React.Component<ISkeletonContentPro
     this.playAnimation();
   }
 
+  componentDidUpdate() {
+    if(this.props.isLoading) {
+      this.playAnimation();
+    }
+  }
+
   playAnimation = () => {
     if (this.props.animationType === "pulse") {
       Animated.loop(


### PR DESCRIPTION
Currently, if you need to go back to the loading state after showing the content, the animation is not started again. 

This PR simply starts the animation again is the component goes back to loading state.