### PR TITLE
fix: downgrade react-native-reanimated

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "expo-linear-gradient": "^8.0.0",
-    "react-native-reanimated": "^1.9.0",
+    "react-native-reanimated": "1.9.0",
     "react-native-redash": "^14.1.1"
   }
 }


### PR DESCRIPTION
Some changes in the latest version of **react-native-reanimated** are causing the following bug: "Unrecognized operator X" and prevents to open the app, i've downgrade version of reanimated to fix temporarily this bug.
Issue: https://github.com/alexZajac/react-native-skeleton-content/issues/27