### PR TITLE
Feature: Add nested child layout, extract skeleton layout into components to reuse.

### DIFF
--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -16,6 +16,7 @@ type _animationDirection =
 export interface ICustomViewStyle extends ViewStyle {
   children?: ICustomViewStyle[];
   key?: number | string;
+  component?: JSX.Element;
 }
 
 export interface ISkeletonContentProps {

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -46,6 +46,15 @@ const childrenToLayout = (children: any, layout: ICustomViewStyle[] = []) => {
       ? Object.assign({}, ...child.props.style)
       : child.props.style;
 
+    // If children is not View component
+    // Then assume it is custom layout component
+    if (child.type?.displayName !== 'View') {
+      return layout.push({
+        ...style,
+        component: child
+      });
+    }
+
     if (child.props?.children) {
       return layout.push({
         ...style,
@@ -384,6 +393,10 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
     }
 
     return bones.map((bone, i) => {
+      if (bone.component) {
+        return bone.component;
+      }
+
       // has a nested layout
       if (bone.children && bone.children!.length > 0) {
         const containerPrefix = bone.key || `bone_container_${i}`;

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -30,11 +30,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     width: '100%'
   },
-  container: {
-    alignItems: 'center',
-    flex: 1,
-    justifyContent: 'center'
-  },
   gradientChild: {
     flex: 1
   }
@@ -80,7 +75,7 @@ const useLayout = () => {
 };
 
 const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
-  containerStyle = styles.container,
+  containerStyle,
   easing = DEFAULT_EASING,
   duration = DEFAULT_DURATION,
   layout = [],


### PR DESCRIPTION
Hello there! 👋 
This PR adds #49.

**Warning** 
**Child layout** only supports View component only.

**What does it means?**
Now you can do:

```js
import React from "react";
import { StyleSheet, View } from "react-native";
import SkeletonContent from "./lib/SkeletonContent";

const AvatarLayout = ({ size = 100 }: { size: number }) => (
  <SkeletonContent isLoading={true}>
    <View style={{ width: size, height: size, borderRadius: size / 2 }} />
  </SkeletonContent>
);

export default function App() {
  return (
    <View style={styles.container}>
      <SkeletonContent isLoading={true}>
        <View
          style={{
            flex: 1,
            flexDirection: "row",
            marginBottom: 10,
          }}
        >
          <AvatarLayout size={50} />
          <View style={{ alignSelf: "flex-start", padding: 10 }}>
            <View style={{ width: 100, height: 10 }} />
            <View style={{ width: 70, height: 20 }} />
            <View />
          </View>
        </View>
        <View style={{ width: 300, height: 250 }} />
      </SkeletonContent>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: "black",
    padding: 10,
  },
});
```

This will return
![image](https://user-images.githubusercontent.com/68330291/125560184-8a4d247f-9a7e-4516-9c47-2f3e70b6d9de.png)


