### PR TITLE
Revert update to Reanimated

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "expo-linear-gradient": "^11.4.0",
-        "react-native-reanimated": "^2.9.1",
+        "react-native-reanimated": "^2.2.0",
         "react-native-redash": "^16.3.0"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "expo-linear-gradient": "^11.4.0",
-        "react-native-reanimated": "^2.2.0",
+        "react-native-reanimated": "2.1.0",
         "react-native-redash": "^16.3.0"
       },
       "devDependencies": {
@@ -5416,11 +5416,6 @@
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
       "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
-    "node_modules/@types/invariant": {
-      "version": "2.2.35",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.35.tgz",
-      "integrity": "sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg=="
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -7589,7 +7584,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "peer": true,
       "dependencies": {
         "node-fetch": "2.6.7"
       }
@@ -9585,7 +9579,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
       "integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
-      "peer": true,
       "dependencies": {
         "cross-fetch": "^3.1.5",
         "fbjs-css-vars": "^1.0.0",
@@ -9599,8 +9592,7 @@
     "node_modules/fbjs-css-vars": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
-      "peer": true
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "node_modules/fetch-retry": {
       "version": "4.1.1",
@@ -13798,11 +13790,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -14846,6 +14833,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -16127,7 +16119,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "peer": true,
       "dependencies": {
         "asap": "~2.0.3"
       }
@@ -16385,22 +16376,19 @@
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g=="
     },
     "node_modules/react-native-reanimated": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.10.0.tgz",
-      "integrity": "sha512-jKm3xz5nX7ABtHzzuuLmawP0pFWP77lXNdIC6AWOceBs23OHUaJ29p4prxr/7Sb588GwTbkPsYkDqVFaE3ezNQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.1.0.tgz",
+      "integrity": "sha512-tlPvvcdf+X7HGQ7g/7npBFhwMznfdk7MHUc9gUB/kp2abSscXNe/kOVKlrNEOO4DS11rNOXc+llFxVFMuNk0zA==",
       "dependencies": {
-        "@babel/plugin-transform-object-assign": "^7.16.7",
-        "@babel/preset-typescript": "^7.16.7",
-        "@types/invariant": "^2.2.35",
-        "invariant": "^2.2.4",
-        "lodash.isequal": "^4.5.0",
-        "setimmediate": "^1.0.5",
+        "@babel/plugin-transform-object-assign": "^7.10.4",
+        "fbjs": "^3.0.0",
+        "mockdate": "^3.0.2",
         "string-hash-64": "^1.0.3"
       },
       "peerDependencies": {
-        "@babel/core": "^7.0.0-0",
         "react": "*",
-        "react-native": "*"
+        "react-native": "*",
+        "react-native-gesture-handler": "*"
       }
     },
     "node_modules/react-native-redash": {
@@ -18752,7 +18740,6 @@
           "url": "https://paypal.me/faisalman"
         }
       ],
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -23500,11 +23487,6 @@
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.41.tgz",
       "integrity": "sha512-ewXv/ceBaJprikMcxCmWU1FKyMAQ2X7a9Gtmzw8fcg2kIePI1crERDM818W+XYrxqdBBOdlf2rm137bU+BltCA=="
     },
-    "@types/invariant": {
-      "version": "2.2.35",
-      "resolved": "https://registry.npmjs.org/@types/invariant/-/invariant-2.2.35.tgz",
-      "integrity": "sha512-DxX1V9P8zdJPYQat1gHyY0xj3efl8gnMVjiM9iCY6y27lj+PoQWkgjt8jDqmovPqULkKVpKRg8J36iQiA+EtEg=="
-    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -25177,7 +25159,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
       "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "peer": true,
       "requires": {
         "node-fetch": "2.6.7"
       }
@@ -26709,7 +26690,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-3.0.4.tgz",
       "integrity": "sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==",
-      "peer": true,
       "requires": {
         "cross-fetch": "^3.1.5",
         "fbjs-css-vars": "^1.0.0",
@@ -26723,8 +26703,7 @@
     "fbjs-css-vars": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
-      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==",
-      "peer": true
+      "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
     },
     "fetch-retry": {
       "version": "4.1.1",
@@ -29882,11 +29861,6 @@
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ=="
-    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -30741,6 +30715,11 @@
       "requires": {
         "minimist": "^1.2.6"
       }
+    },
+    "mockdate": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mockdate/-/mockdate-3.0.5.tgz",
+      "integrity": "sha512-iniQP4rj1FhBdBYS/+eQv7j1tadJ9lJtdzgOpvsOHng/GbcDh2Fhdeq+ZRldrPYdXvCyfFUmFeEwEGXZB5I/AQ=="
     },
     "ms": {
       "version": "2.1.2",
@@ -31708,7 +31687,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
       "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "peer": true,
       "requires": {
         "asap": "~2.0.3"
       }
@@ -31934,16 +31912,13 @@
       "integrity": "sha512-+4JpbIx42zGTONhBTIXSyfyHICHC29VTvhkkoUOJAh/XHPEixpuBduYgf6Y4y9wsN1ARlQhBBoptTvXvAFQf5g=="
     },
     "react-native-reanimated": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.10.0.tgz",
-      "integrity": "sha512-jKm3xz5nX7ABtHzzuuLmawP0pFWP77lXNdIC6AWOceBs23OHUaJ29p4prxr/7Sb588GwTbkPsYkDqVFaE3ezNQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-2.1.0.tgz",
+      "integrity": "sha512-tlPvvcdf+X7HGQ7g/7npBFhwMznfdk7MHUc9gUB/kp2abSscXNe/kOVKlrNEOO4DS11rNOXc+llFxVFMuNk0zA==",
       "requires": {
-        "@babel/plugin-transform-object-assign": "^7.16.7",
-        "@babel/preset-typescript": "^7.16.7",
-        "@types/invariant": "^2.2.35",
-        "invariant": "^2.2.4",
-        "lodash.isequal": "^4.5.0",
-        "setimmediate": "^1.0.5",
+        "@babel/plugin-transform-object-assign": "^7.10.4",
+        "fbjs": "^3.0.0",
+        "mockdate": "^3.0.2",
         "string-hash-64": "^1.0.3"
       }
     },
@@ -33775,8 +33750,7 @@
     "ua-parser-js": {
       "version": "0.7.31",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
-      "peer": true
+      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
     },
     "uglify-es": {
       "version": "3.3.9",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "expo-linear-gradient": "^11.4.0",
-    "react-native-reanimated": "^2.9.1",
+    "react-native-reanimated": "^2.2.0",
     "react-native-redash": "^16.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "dependencies": {
     "expo-linear-gradient": "^11.4.0",
-    "react-native-reanimated": "^2.2.0",
+    "react-native-reanimated": "2.1.0",
     "react-native-redash": "^16.3.0"
   }
 }

--- a/src/SkeletonContent.tsx
+++ b/src/SkeletonContent.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
-import {LayoutChangeEvent, StyleSheet, View } from 'react-native';
+import { LayoutChangeEvent, StyleSheet, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Animated, { interpolateNode } from 'react-native-reanimated';
 import {
   interpolateColor,
   loop,
-  useValue
+  useValue,
 } from 'react-native-redash/lib/module/v1';
 import {
   ICustomViewStyle,
@@ -18,7 +18,7 @@ import {
   DEFAULT_HIGHLIGHT_COLOR,
   DEFAULT_LOADING,
   ISkeletonContentProps,
-  IDirection
+  IDirection,
 } from './Constants';
 
 const { useCode, set, cond, eq } = Animated;
@@ -28,16 +28,16 @@ const styles = StyleSheet.create({
   absoluteGradient: {
     height: '100%',
     position: 'absolute',
-    width: '100%'
+    width: '100%',
   },
   container: {
     alignItems: 'center',
     flex: 1,
-    justifyContent: 'center'
+    justifyContent: 'center',
   },
   gradientChild: {
-    flex: 1
-  }
+    flex: 1,
+  },
 });
 
 const useLayout = () => {
@@ -61,7 +61,7 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
   isLoading = DEFAULT_LOADING,
   boneColor = DEFAULT_BONE_COLOR,
   highlightColor = DEFAULT_HIGHLIGHT_COLOR,
-  children
+  children,
 }) => {
   const animationValue = useValue(0);
   const loadingValue = useValue(isLoading ? 1 : 0);
@@ -79,9 +79,9 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
               animationValue,
               loop({
                 duration,
-                easing
+                easing,
               })
-            )
+            ),
           ],
           [
             set(
@@ -89,11 +89,11 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
               loop({
                 duration: duration! / 2,
                 easing,
-                boomerang: true
+                boomerang: true,
               })
-            )
+            ),
           ]
-        )
+        ),
       ]),
     [loadingValue, shiverValue, animationValue]
   );
@@ -146,7 +146,7 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
       width: boneWidth,
       height: boneHeight,
       borderRadius: borderRadius || DEFAULT_BORDER_RADIUS,
-      ...boneLayout
+      ...boneLayout,
     };
     if (animationType !== 'pulse') {
       boneStyle.overflow = 'hidden';
@@ -190,9 +190,9 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
       {
         backgroundColor: interpolateColor(animationValue, {
           inputRange: [0, 1],
-          outputRange: [boneColor!, highlightColor!]
-        })
-      }
+          outputRange: [boneColor!, highlightColor!],
+        }),
+      },
     ];
     if (animationType === 'none') pulseStyles.pop();
     return pulseStyles;
@@ -228,7 +228,7 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
     ) {
       const interpolatedPosition = interpolateNode(animationValue, {
         inputRange: [0, 1],
-        outputRange: getPositionRange(boneLayout)
+        outputRange: getPositionRange(boneLayout),
       });
       if (
         animationDirection === 'verticalTop' ||
@@ -296,11 +296,11 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
       }
       let translateX = interpolateNode(animationValue, {
         inputRange: [0, 1],
-        outputRange: xOutputRange
+        outputRange: xOutputRange,
       });
       let translateY = interpolateNode(animationValue, {
         inputRange: [0, 1],
-        outputRange: yOutputRange
+        outputRange: yOutputRange,
       });
       // swapping the translates if width is the main dim
       if (mainDimension === boneWidth)
@@ -337,7 +337,7 @@ const SkeletonContent: React.FunctionComponent<ISkeletonContentProps> = ({
   ): JSX.Element => {
     const animatedStyle: any = {
       transform: [getGradientTransform(layoutStyle)],
-      ...getGradientSize(layoutStyle)
+      ...getGradientSize(layoutStyle),
     };
     return (
       <View key={layoutStyle.key || key} style={getBoneStyles(layoutStyle)}>


### PR DESCRIPTION
@alexZajac Looks like I made a mistake with the last branch I pushed. I didn't realized that between reanimated@2.1.0 and reanimated@2.2.0 they removed all deprecated types. This causes my changes to crash. So I have reverted my upgrade for reanimated while keeping the rest of the dependencies upgraded. I have tested this branch in my project and all works from here. 

I am calling this the safe branch and believe it should be released as a fix for the last branch ASAP. See my other branch as well #77 